### PR TITLE
Add support for Minecraft versions in the Downloads API

### DIFF
--- a/src/main/java/io/papermc/bibliothek/controller/v2/VersionBuildController.java
+++ b/src/main/java/io/papermc/bibliothek/controller/v2/VersionBuildController.java
@@ -152,12 +152,12 @@ public class VersionBuildController {
     boolean promoted,
     @Schema(name = "changes")
     List<Build.Change> changes,
-    @Schema(name = "downloads")
-    Map<String, Build.Download> downloads,
     @Schema(name = "supportedJavaVersions")
     List<String> supportedJavaVersions,
     @Schema(name = "supportedBedrockVersions")
-    List<String> supportedBedrockVersions
+    List<String> supportedBedrockVersions,
+    @Schema(name = "downloads")
+    Map<String, Build.Download> downloads
   ) {
     static BuildResponse from(final Project project, final Version version, final Build build) {
       return new BuildResponse(
@@ -169,9 +169,9 @@ public class VersionBuildController {
         build.channelOrDefault(),
         build.promotedOrDefault(),
         build.changes(),
-        build.downloads(),
         build.supportedJavaVersions(),
-        build.supportedBedrockVersions()
+        build.supportedBedrockVersions(),
+        build.downloads()
       );
     }
   }

--- a/src/main/java/io/papermc/bibliothek/controller/v2/VersionBuildController.java
+++ b/src/main/java/io/papermc/bibliothek/controller/v2/VersionBuildController.java
@@ -153,7 +153,11 @@ public class VersionBuildController {
     @Schema(name = "changes")
     List<Build.Change> changes,
     @Schema(name = "downloads")
-    Map<String, Build.Download> downloads
+    Map<String, Build.Download> downloads,
+    @Schema(name = "supportedJavaVersions")
+    List<String> supportedJavaVersions,
+    @Schema(name = "supportedBedrockVersions")
+    List<String> supportedBedrockVersions
   ) {
     static BuildResponse from(final Project project, final Version version, final Build build) {
       return new BuildResponse(
@@ -165,7 +169,9 @@ public class VersionBuildController {
         build.channelOrDefault(),
         build.promotedOrDefault(),
         build.changes(),
-        build.downloads()
+        build.downloads(),
+        build.supportedJavaVersions(),
+        build.supportedBedrockVersions()
       );
     }
   }

--- a/src/main/java/io/papermc/bibliothek/controller/v2/VersionBuildController.java
+++ b/src/main/java/io/papermc/bibliothek/controller/v2/VersionBuildController.java
@@ -152,10 +152,8 @@ public class VersionBuildController {
     boolean promoted,
     @Schema(name = "changes")
     List<Build.Change> changes,
-    @Schema(name = "supportedJavaVersions")
-    List<String> supportedJavaVersions,
-    @Schema(name = "supportedBedrockVersions")
-    List<String> supportedBedrockVersions,
+    @Schema(name = "metadata")
+    Build.Metadata metadata,
     @Schema(name = "downloads")
     Map<String, Build.Download> downloads
   ) {
@@ -169,8 +167,7 @@ public class VersionBuildController {
         build.channelOrDefault(),
         build.promotedOrDefault(),
         build.changes(),
-        build.supportedJavaVersions(),
-        build.supportedBedrockVersions(),
+        build.metadata(),
         build.downloads()
       );
     }

--- a/src/main/java/io/papermc/bibliothek/controller/v2/VersionBuildsController.java
+++ b/src/main/java/io/papermc/bibliothek/controller/v2/VersionBuildsController.java
@@ -125,7 +125,9 @@ public class VersionBuildsController {
           build.channelOrDefault(),
           build.promotedOrDefault(),
           build.changes(),
-          build.downloads()
+          build.downloads(),
+          build.supportedJavaVersions(),
+          build.supportedBedrockVersions()
         )).toList()
       );
     }
@@ -143,7 +145,11 @@ public class VersionBuildsController {
       @Schema(name = "changes")
       List<Build.Change> changes,
       @Schema(name = "downloads")
-      Map<String, Build.Download> downloads
+      Map<String, Build.Download> downloads,
+      @Schema(name = "supportedJavaVersions")
+      List<String> supportedJavaVersions,
+      @Schema(name = "supportedBedrockVersions")
+      List<String> supportedBedrockVersions
     ) {
     }
   }

--- a/src/main/java/io/papermc/bibliothek/controller/v2/VersionBuildsController.java
+++ b/src/main/java/io/papermc/bibliothek/controller/v2/VersionBuildsController.java
@@ -125,9 +125,9 @@ public class VersionBuildsController {
           build.channelOrDefault(),
           build.promotedOrDefault(),
           build.changes(),
-          build.downloads(),
           build.supportedJavaVersions(),
-          build.supportedBedrockVersions()
+          build.supportedBedrockVersions(),
+          build.downloads()
         )).toList()
       );
     }
@@ -144,12 +144,12 @@ public class VersionBuildsController {
       boolean promoted,
       @Schema(name = "changes")
       List<Build.Change> changes,
-      @Schema(name = "downloads")
-      Map<String, Build.Download> downloads,
       @Schema(name = "supportedJavaVersions")
       List<String> supportedJavaVersions,
       @Schema(name = "supportedBedrockVersions")
-      List<String> supportedBedrockVersions
+      List<String> supportedBedrockVersions,
+      @Schema(name = "downloads")
+      Map<String, Build.Download> downloads
     ) {
     }
   }

--- a/src/main/java/io/papermc/bibliothek/controller/v2/VersionBuildsController.java
+++ b/src/main/java/io/papermc/bibliothek/controller/v2/VersionBuildsController.java
@@ -125,8 +125,7 @@ public class VersionBuildsController {
           build.channelOrDefault(),
           build.promotedOrDefault(),
           build.changes(),
-          build.supportedJavaVersions(),
-          build.supportedBedrockVersions(),
+          build.metadata(),
           build.downloads()
         )).toList()
       );
@@ -144,10 +143,8 @@ public class VersionBuildsController {
       boolean promoted,
       @Schema(name = "changes")
       List<Build.Change> changes,
-      @Schema(name = "supportedJavaVersions")
-      List<String> supportedJavaVersions,
-      @Schema(name = "supportedBedrockVersions")
-      List<String> supportedBedrockVersions,
+      @Schema(name = "metadata")
+      Build.Metadata metadata,
       @Schema(name = "downloads")
       Map<String, Build.Download> downloads
     ) {

--- a/src/main/java/io/papermc/bibliothek/database/model/Build.java
+++ b/src/main/java/io/papermc/bibliothek/database/model/Build.java
@@ -109,7 +109,7 @@ public record Build(
     @Schema
     List<String> versions
   ) {
-  } 
+  }
 
   @Schema
   public record BedrockMetadata(

--- a/src/main/java/io/papermc/bibliothek/database/model/Build.java
+++ b/src/main/java/io/papermc/bibliothek/database/model/Build.java
@@ -51,7 +51,9 @@ public record Build(
   @JsonProperty
   @Nullable Channel channel,
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  @Nullable Boolean promoted
+  @Nullable Boolean promoted,
+  List<String> supportedJavaVersions,
+  List<String> supportedBedrockVersions
 ) {
   public Channel channelOrDefault() {
     return Objects.requireNonNullElse(this.channel(), Build.Channel.DEFAULT);

--- a/src/main/java/io/papermc/bibliothek/database/model/Build.java
+++ b/src/main/java/io/papermc/bibliothek/database/model/Build.java
@@ -52,8 +52,8 @@ public record Build(
   @Nullable Channel channel,
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @Nullable Boolean promoted,
-  List<String> supportedJavaVersions,
-  List<String> supportedBedrockVersions
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Nullable Metadata metadata
 ) {
   public Channel channelOrDefault() {
     return Objects.requireNonNullElse(this.channel(), Build.Channel.DEFAULT);
@@ -91,5 +91,30 @@ public record Build(
     // NOTE: this pattern cannot contain any capturing groups
     @Language("RegExp")
     public static final String PATTERN = "[a-zA-Z0-9._-]+";
+  }
+
+  @Schema
+  public record Metadata(
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Nullable JavaMetadata java,
+
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Nullable BedrockMetadata bedrock
+  ) {
+  }
+
+  @Schema
+  public record JavaMetadata(
+    @Schema
+    List<String> versions
+  ) {
+  } 
+
+  @Schema
+  public record BedrockMetadata(
+    @Schema
+    List<String> versions
+  ) {
   }
 }


### PR DESCRIPTION
Unsure whether its best to store in the builds table or the versions table